### PR TITLE
Full slugs and subdomain bug

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -66,7 +66,8 @@ const arenaContext = new Promise( ( resolve, reject ) => {
           status:    context.CHANNEL.status,
           id:        context.CHANNEL.user.id,
           user_slug: context.CHANNEL.user.slug,
-          user_name: context.CHANNEL.user.full_name
+          user_name: context.CHANNEL.user.full_name,
+          full_slug: [context.CHANNEL.user.slug, context.CHANNEL.slug].join('/')
         } );
 
       } else if ( context.CURRENT_ACTION && context.CURRENT_ACTION == 'profile' ) {

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
     "js": [
       "core/inject.js",
       "tools/maps/content.js",
+      // "tools/maps/bower_components/vis/dist/vis.js",
       "tools/maps/pure.js",
       "tools/print/content.js",
       "tools/show/content.js",

--- a/manifest.json
+++ b/manifest.json
@@ -14,14 +14,16 @@
     "js": [
       "core/inject.js",
       "tools/maps/content.js",
-      "tools/maps/bower_components/vis/dist/vis.js",
       "tools/maps/pure.js",
       "tools/print/content.js",
       "tools/show/content.js",
       "tools/history/content.js",
       "core/content.js"
       ],
-    "matches": ["https://www.are.na/*"]
+    "matches": [
+      "https://www.are.na/*",
+      "https://are.na/*"
+      ]
   }],
   "background": {
     "scripts": [

--- a/tools/history/content.js
+++ b/tools/history/content.js
@@ -36,7 +36,7 @@ arenaContext.then( context => {
         }
 
         for( let i = 0; i < slugs.length; i++ ) {
-          history_canvas_list.innerHTML += '<li><a href="https://are.na/' +  slugs[ i ] + '">' + titles[ i ] + '</a></li>';
+          history_canvas_list.innerHTML += '<li><a href="/' +  slugs[ i ] + '">' + titles[ i ] + '</a></li>';
         }
 
         history_canvas.appendChild( history_canvas_list );

--- a/tools/history/content.js
+++ b/tools/history/content.js
@@ -20,7 +20,7 @@ arenaContext.then( context => {
 
         if ( data.slugs && data.titles && context.slug && context.title ) {
 
-          slugs  = [ context.slug ].concat( data.slugs );
+          slugs  = [ (context.full_slug || context.slug) ].concat( data.slugs );
           titles = [ context.title ].concat( data.titles );
 
         } else if ( data.slugs && data.titles ){


### PR DESCRIPTION
This PR addresses 2 minor issues I came across.

1. Arena does not preserve login when you switch between `https://are.na` and `https://www.are.na`. So I switched the history tool to use hrefs that only change the path, not the host.

2. Private channels result in a 401 (permission denied) error when using only the channel's slug in an href and not a full href which includes the user slug. I changed the history tool to use a full slug when possible.